### PR TITLE
Patch ws DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5981,7 +5981,7 @@
           "dev": true
         },
         "ws": {
-          "version": "7.5.9",
+          "version": "7.5.10",
           "bundled": true,
           "dev": true
         },


### PR DESCRIPTION
## Summary
- bump ws in package-lock to 7.5.10 to mitigate DoS vulnerability

## Testing
- `npm test` *(fails: `grunt: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687609b52a80832c824db297ac8ba1f8